### PR TITLE
Add config flow for Tado X integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Tado_X_HA_Integration
+# Tado X Home Assistant Integration
+
+This custom component integrates Tado devices using a refresh token and home ID.
+
+The config flow validates your credentials against the Tado API and prevents duplicate entries.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,20 @@
+"""Tado X integration setup."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Tado X from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = entry.data
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Tado X config entry."""
+    hass.data[DOMAIN].pop(entry.entry_id, None)
+    return True

--- a/config_flow.py
+++ b/config_flow.py
@@ -1,0 +1,97 @@
+"""Config flow for Tado X integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+import aiohttp
+
+from homeassistant import config_entries, exceptions
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+from .const import DOMAIN, CONF_REFRESH_TOKEN, CONF_HOME_ID
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_REFRESH_TOKEN): str,
+        vol.Required(CONF_HOME_ID): str,
+    }
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    session = aiohttp_client.async_get_clientsession(hass)
+    token_payload = {
+        "grant_type": "refresh_token",
+        "client_id": "tado-web-app",
+        "refresh_token": data[CONF_REFRESH_TOKEN],
+        "scope": "home.user",
+    }
+    try:
+        resp = await session.post("https://auth.tado.com/oauth/token", data=token_payload, timeout=10)
+    except aiohttp.ClientError as err:  # pragma: no cover - network failure
+        raise CannotConnect from err
+    if resp.status != 200:
+        raise InvalidAuth
+    token = await resp.json()
+
+    headers = {"Authorization": f"Bearer {token['access_token']}"}
+    try:
+        dev_resp = await session.get(
+            f"https://my.tado.com/api/v2/homes/{data[CONF_HOME_ID]}/devices",
+            headers=headers,
+            timeout=10,
+        )
+    except aiohttp.ClientError as err:  # pragma: no cover - network failure
+        raise CannotConnect from err
+
+    if dev_resp.status != 200:
+        raise InvalidAuth
+
+    devices = await dev_resp.json()
+    return {"title": f"Tado {data[CONF_HOME_ID]}", "devices": devices}
+
+
+class TadoXConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Tado X."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pragma: no cover - unexpected
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                for entry in self._async_current_entries():
+                    if entry.data.get(CONF_HOME_ID) == user_input[CONF_HOME_ID]:
+                        self.hass.config_entries.async_update_entry(entry, data=user_input)
+                        await self.hass.config_entries.async_reload(entry.entry_id)
+                        return self.async_abort(reason="reauth_successful")
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA, errors=errors)
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""
+

--- a/const.py
+++ b/const.py
@@ -1,6 +1,10 @@
 # custom_components/tado_x/const.py
 from homeassistant.const import Platform
 
+CONF_REFRESH_TOKEN = "refresh_token"
+CONF_HOME_ID = "home_id"
+
 DOMAIN = "tado_x"
 PLATFORMS = [Platform.CLIMATE, Platform.NUMBER]
 DEFAULT_SCAN_INTERVAL = 30  # Sekunden, falls du zyklisch aktualisieren willst
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "tado_x",
+  "name": "Tado X Integration",
+  "version": "0.1.0",
+  "documentation": "https://example.com",
+  "codeowners": [],
+  "config_flow": true,
+  "requirements": []
+}


### PR DESCRIPTION
## Summary
- add Home Assistant config flow asking for refresh token and home ID
- validate credentials via Tado API and reuse existing entries to avoid duplicates
- introduce basic integration scaffolding and manifest

## Testing
- `python -m py_compile const.py config_flow.py __init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b988349b448330999ce47fb805878f