### PR TITLE
Add TadoX offset number entity

### DIFF
--- a/custom_components/tado_x/__init__.py
+++ b/custom_components/tado_x/__init__.py
@@ -1,0 +1,1 @@
+"""Tado X integration."""

--- a/custom_components/tado_x/const.py
+++ b/custom_components/tado_x/const.py
@@ -1,0 +1,6 @@
+# custom_components/tado_x/const.py
+from homeassistant.const import Platform
+
+DOMAIN = "tado_x"
+PLATFORMS = [Platform.CLIMATE, Platform.NUMBER]
+DEFAULT_SCAN_INTERVAL = 30  # Sekunden, falls du zyklisch aktualisieren willst

--- a/custom_components/tado_x/number.py
+++ b/custom_components/tado_x/number.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Tado X offset number entity."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    api = data["api"]
+    serial = data["serial"]
+    async_add_entities([TadoXOffsetNumber(api, serial)])
+
+
+class TadoXOffsetNumber(NumberEntity):
+    """Entity to control the temperature offset of a Tado X device."""
+
+    _attr_name = "Temperature Offset"
+    _attr_native_min_value = -5.0
+    _attr_native_max_value = 5.0
+    _attr_native_step = 0.1
+
+    def __init__(self, api, serial: str) -> None:
+        """Initialize the offset number."""
+        self.api = api
+        self._serial = serial
+        self._attr_unique_id = f"{serial}_temperature_offset"
+        self._attr_native_value = None
+
+    async def async_set_value(self, value: float) -> None:
+        """Update the offset value via the API."""
+        await self.api.async_update_temperature_offset(self._serial, value)
+        self._attr_native_value = value
+        self.async_write_ha_state()
+
+    async def async_update(self) -> None:
+        """Fetch the latest offset from the API."""
+        offset = await self.api.async_get_temperature_offset(self._serial)
+        self._attr_native_value = offset


### PR DESCRIPTION
## Summary
- add TadoXOffsetNumber as a NumberEntity to manage temperature offset
- include async methods for updating and retrieving offset from API

## Testing
- `python -m py_compile custom_components/tado_x/number.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9883d68a48330803bc2652267034e