### PR TITLE
Add temperature offset retrieval and robust update handling

### DIFF
--- a/custom_components/tado_x/api.py
+++ b/custom_components/tado_x/api.py
@@ -72,6 +72,12 @@ class TadoXApi:
         url = f"{API_BASE}/homes/{home_id}/zones"
         return await self._async_request("GET", url)
 
+    async def async_get_temperature_offset(self, device_id: str) -> float | None:
+        """Retrieve the current temperature offset for a device."""
+        url = f"{API_BASE}/devices/{device_id}/temperatureOffset"
+        data = await self._async_request("GET", url)
+        return data.get("celsius")
+
     async def async_update_temperature_offset(self, device_id: str, offset: float) -> Any:
         """Update the temperature offset for a device."""
         url = f"{API_BASE}/devices/{device_id}/temperatureOffset"

--- a/custom_components/tado_x/number.py
+++ b/custom_components/tado_x/number.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.number import NumberEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -43,5 +48,12 @@ class TadoXOffsetNumber(NumberEntity):
 
     async def async_update(self) -> None:
         """Fetch the latest offset from the API."""
-        offset = await self.api.async_get_temperature_offset(self._serial)
-        self._attr_native_value = offset
+        try:
+            offset = await self.api.async_get_temperature_offset(self._serial)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.error(
+                "Error fetching temperature offset for %s: %s", self._serial, err
+            )
+            return
+        if offset is not None:
+            self._attr_native_value = offset


### PR DESCRIPTION
## Summary
- Add API helper to fetch device temperature offset
- Use offset in number entity update with error handling

## Testing
- `python -m py_compile custom_components/tado_x/api.py custom_components/tado_x/number.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b98f1fcd388330a65ea884219b3325