### PR TITLE
Add basic Tado X climate entity

### DIFF
--- a/custom_components/tado_x/__init__.py
+++ b/custom_components/tado_x/__init__.py
@@ -1,1 +1,23 @@
 """Tado X integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN, PLATFORMS
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Tado X from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = entry.data
+    await hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Tado X config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/tado_x/climate.py
+++ b/custom_components/tado_x/climate.py
@@ -1,0 +1,48 @@
+"""Climate platform for Tado X."""
+from __future__ import annotations
+
+from homeassistant.components.climate import ClimateEntity, HVACMode
+from homeassistant.const import TEMP_CELSIUS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Tado X climate entities."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([TadoXClimate(data)])
+
+
+class TadoXClimate(ClimateEntity):
+    """Representation of a Tado X climate entity."""
+
+    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+
+    def __init__(self, data: dict) -> None:
+        """Initialize the climate device."""
+        self._data = data
+        self._attr_name = data.get("name", "Tado X Climate")
+        self._attr_unique_id = f"{data.get('serial', 'tado_x')}_climate"
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return the current HVAC mode."""
+        return self._data.get("mode", HVACMode.OFF)
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        return self._data.get("temperature")
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return extra state attributes."""
+        return {"heating_power": self._data.get("heatingPower")}

--- a/custom_components/tado_x/const.py
+++ b/custom_components/tado_x/const.py
@@ -2,5 +2,6 @@
 from homeassistant.const import Platform
 
 DOMAIN = "tado_x"
-PLATFORMS = [Platform.CLIMATE, Platform.NUMBER]
+# Platforms supported by this integration.
+PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.NUMBER]
 DEFAULT_SCAN_INTERVAL = 30  # Sekunden, falls du zyklisch aktualisieren willst


### PR DESCRIPTION
## Summary
- introduce climate platform entity to represent temperature, mode and heating power
- load climate entities during config entry setup
- document supported platforms in constants

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b98f2278708330a6cab2d454097295