### PR TITLE
Move manifest and add HACS metadata

### DIFF
--- a/custom_components/tado_x/manifest.json
+++ b/custom_components/tado_x/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "tado_x",
+  "name": "Tado X Integration",
+  "version": "0.1.0",
+  "documentation": "https://github.com/Zanooon97/Tado_X_HA_Integration",
+  "codeowners": ["@Zanooon97"],
+  "homeassistant": "2024.2.0",
+  "config_flow": true,
+  "requirements": []
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Tado X",
+  "domain": "tado_x",
+  "render_readme": true,
+  "homeassistant": "2024.2.0"
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,0 @@
-{
-  "domain": "tado_x",
-  "name": "Tado X Integration",
-  "version": "0.1.0",
-  "documentation": "https://example.com",
-  "codeowners": [],
-  "config_flow": true,
-  "requirements": []
-}


### PR DESCRIPTION
## Summary
- move manifest.json into custom_components/tado_x and add codeowners, docs link, and minimum Home Assistant version
- add hacs.json with project metadata

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b98f224e9483309b8a0e207df09552