### PR TITLE
Initialize TadoX API client during setup

### DIFF
--- a/custom_components/tado_x/__init__.py
+++ b/custom_components/tado_x/__init__.py
@@ -3,14 +3,24 @@ from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN, PLATFORMS
+from .api import TadoXApi
+from .const import CONF_HOME_ID, DOMAIN, PLATFORMS
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Tado X from a config entry."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    api = TadoXApi(hass, entry, session)
+    await api.async_refresh_token()
+    home_id = int(entry.data[CONF_HOME_ID])
+    devices = await api.async_get_devices(home_id)
+    serial = devices[0].get("serialNo") if devices else None
+
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
+    hass.data[DOMAIN][entry.entry_id] = {"api": api, "serial": serial}
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/tado_x/api.py
+++ b/custom_components/tado_x/api.py
@@ -72,6 +72,11 @@ class TadoXApi:
         url = f"{API_BASE}/homes/{home_id}/zones"
         return await self._async_request("GET", url)
 
+    async def async_get_devices(self, home_id: int) -> Any:
+        """Return devices for a home."""
+        url = f"{API_BASE}/homes/{home_id}/devices"
+        return await self._async_request("GET", url)
+
     async def async_get_temperature_offset(self, device_id: str) -> float | None:
         """Retrieve the current temperature offset for a device."""
         url = f"{API_BASE}/devices/{device_id}/temperatureOffset"


### PR DESCRIPTION
## Summary
- Instantiate `TadoXApi` using Home Assistant's aiohttp client
- Fetch first device serial number and store API and serial in `hass.data`
- Expose helper to list devices from the Tado X API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b993e7c158833090e3c29af10d3876