### PR TITLE
Add HACS config and manifest metadata

### DIFF
--- a/custom_components/tado_x/manifest.json
+++ b/custom_components/tado_x/manifest.json
@@ -2,8 +2,8 @@
   "domain": "tado_x",
   "name": "Tado X Integration",
   "version": "0.1.0",
-  "documentation": "https://example.com",
-  "codeowners": [],
+  "documentation": "https://github.com/Zanooon97/Tado_X_HA_Integration",
+  "codeowners": ["@Zanooon97"],
   "config_flow": true,
   "requirements": []
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Tado X",
+  "domain": "tado_x",
+  "country": "any"
+}


### PR DESCRIPTION
## Summary
- add hacs.json for HACS metadata
- link real documentation URL and codeowner in manifest

## Testing
- `python -m json.tool hacs.json`
- `python -m json.tool custom_components/tado_x/manifest.json`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9949f08008330b221ba787c3c6ab8