### PR TITLE
Use hops endpoint for rooms and add room-based entities

### DIFF
--- a/custom_components/tado_x/api.py
+++ b/custom_components/tado_x/api.py
@@ -74,7 +74,7 @@ class TadoXApi:
 
     async def async_get_rooms_devices(self, home_id: int) -> Any:
         """Return rooms with their devices for a home."""
-        url = f"{API_BASE}/homes/{home_id}/zones"
+        url = f"{HOPS_BASE}/homes/{home_id}/rooms"
         return await self._async_request("GET", url)
 
     async def async_get_devices(self, home_id: int) -> Any:
@@ -82,14 +82,14 @@ class TadoXApi:
         url = f"{API_BASE}/homes/{home_id}/devices"
         return await self._async_request("GET", url)
 
-    async def async_get_temperature(self, serial: str) -> dict[str, Any] | None:
-        """Retrieve current and target temperatures for a device."""
+    async def async_get_temperature(self, room_id: str) -> dict[str, Any] | None:
+        """Retrieve current and target temperatures for a room."""
         home_id = self._entry.data.get(CONF_HOME_ID)
-        url = f"{HOPS_BASE}/homes/{home_id}/rooms/{serial}"
+        url = f"{HOPS_BASE}/homes/{home_id}/rooms/{room_id}"
         try:
             data = await self._async_request("GET", url)
         except aiohttp.ClientError as err:
-            _LOGGER.error("Error fetching temperature for %s: %s", serial, err)
+            _LOGGER.error("Error fetching temperature for %s: %s", room_id, err)
             raise
         return {
             "current": data.get("current")
@@ -100,15 +100,15 @@ class TadoXApi:
             or data.get("targetTemperature"),
         }
 
-    async def async_set_temperature(self, serial: str, value: float) -> None:
-        """Set a new target temperature for a device."""
+    async def async_set_temperature(self, room_id: str, value: float) -> None:
+        """Set a new target temperature for a room."""
         home_id = self._entry.data.get(CONF_HOME_ID)
-        url = f"{HOPS_BASE}/homes/{home_id}/rooms/{serial}"
+        url = f"{HOPS_BASE}/homes/{home_id}/rooms/{room_id}"
         payload = {"target": value}
         try:
             await self._async_request("PUT", url, json=payload)
         except aiohttp.ClientError as err:
-            _LOGGER.error("Error setting temperature for %s: %s", serial, err)
+            _LOGGER.error("Error setting temperature for %s: %s", room_id, err)
             raise
 
     async def async_get_temperature_offset(self, device_id: str) -> float | None:

--- a/custom_components/tado_x/climate.py
+++ b/custom_components/tado_x/climate.py
@@ -7,26 +7,36 @@ from homeassistant.components.climate.const import (
     HVACMode,
     ClimateEntityFeature,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_HOME_ID
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigType,
+    entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Tado X climate entity."""
+    """Set up the Tado X climate entities."""
     data = hass.data[DOMAIN][entry.entry_id]
     api = data["api"]
-    serial = data["serial"]
-    async_add_entities([TadoXClimate(api, serial)])
+    home_id = entry.data[CONF_HOME_ID]
+    rooms = await api.async_get_rooms_devices(home_id)
+    entities = []
+    for room in rooms:
+        room_id = room.get("id") or room.get("serialNo")
+        if room_id is None:
+            continue
+        name = room.get("name") or "Tado X Climate"
+        current = room.get("current") or room.get("currentTemp") or room.get("currentTemperature")
+        target = room.get("target") or room.get("targetTemp") or room.get("targetTemperature")
+        entities.append(TadoXClimate(api, room_id, name, current, target))
+    async_add_entities(entities)
 
 
 class TadoXClimate(ClimateEntity):
@@ -37,30 +47,30 @@ class TadoXClimate(ClimateEntity):
     _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
-    def __init__(self, api, serial: str) -> None:
+    def __init__(self, api, room_id: str, name: str, current: float | None, target: float | None) -> None:
         """Initialize the climate device."""
         self.api = api
-        self._serial = serial
-        self._attr_unique_id = f"{serial}_climate"
-        self._attr_name = "Tado X Climate"
-        self._attr_target_temperature = None
-        self._attr_current_temperature = None
+        self._room_id = room_id
+        self._attr_unique_id = f"{room_id}_climate"
+        self._attr_name = name
+        self._attr_target_temperature = target
+        self._attr_current_temperature = current
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             return
-        await self.api.async_set_temperature(self._serial, temperature)
+        await self.api.async_set_temperature(self._room_id, temperature)
         self._attr_target_temperature = temperature
         self.async_write_ha_state()
 
     async def async_update(self) -> None:
         """Fetch new state data for the climate entity."""
         try:
-            data = await self.api.async_get_temperature(self._serial)
+            data = await self.api.async_get_temperature(self._room_id)
         except Exception as err:  # pylint: disable=broad-except
-            _LOGGER.error("Error fetching climate data for %s: %s", self._serial, err)
+            _LOGGER.error("Error fetching climate data for %s: %s", self._room_id, err)
             return
         if data:
             self._attr_current_temperature = data.get("current")


### PR DESCRIPTION
## Summary
- use `hops.tado.com` rooms endpoint
- initialize climate entities with room IDs and names

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9a05987b48330ab2c8c3ef5234af5