### PR TITLE
Add device metadata and device_info for tado° X entities

### DIFF
--- a/custom_components/tado_x/__init__.py
+++ b/custom_components/tado_x/__init__.py
@@ -15,11 +15,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api = TadoXApi(hass, entry, session)
     await api.async_refresh_token()
     home_id = int(entry.data[CONF_HOME_ID])
-    devices = await api.async_get_devices(home_id)
-    serial = devices[0].get("serialNo") if devices else None
+
+    rooms_data = await api.async_get_rooms_devices(home_id)
+    rooms: dict[str, dict[str, str | float | None]] = {}
+    for room in rooms_data or []:
+        room_id = str(room.get("id") or room.get("serialNo"))
+        if not room_id:
+            continue
+        room_name = room.get("name")
+        current = (
+            room.get("current")
+            or room.get("currentTemp")
+            or room.get("currentTemperature")
+        )
+        target = (
+            room.get("target")
+            or room.get("targetTemp")
+            or room.get("targetTemperature")
+        )
+        humidity = room.get("humidity")
+        heating_power = room.get("heatingPower")
+
+        device = (room.get("devices") or [None])[0] or {}
+        serial = device.get("serialNo")
+        model = device.get("model") or device.get("type")
+        firmware = device.get("firmware") or device.get("firmwareVersion")
+        battery_state = device.get("batteryState") or room.get("batteryState")
+
+        rooms[room_id] = {
+            "serial": serial,
+            "model": model,
+            "firmware": firmware,
+            "name": room_name,
+            "current": current,
+            "target": target,
+            "humidity": humidity,
+            "heatingPower": heating_power,
+            "batteryState": battery_state,
+        }
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {"api": api, "serial": serial}
+    hass.data[DOMAIN][entry.entry_id] = {"api": api, "rooms": rooms}
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/custom_components/tado_x/api.py
+++ b/custom_components/tado_x/api.py
@@ -90,7 +90,7 @@ class TadoXApi:
         return await self._async_request("GET", url)
 
     async def async_get_temperature(self, room_id: str) -> dict[str, Any] | None:
-        """Retrieve current and target temperatures for a room."""
+        """Retrieve room information including temperatures and other stats."""
         home_id = self._entry.data.get(CONF_HOME_ID)
         url = f"{HOPS_BASE}/homes/{home_id}/rooms/{room_id}"
         try:
@@ -105,6 +105,9 @@ class TadoXApi:
             "target": data.get("target")
             or data.get("targetTemp")
             or data.get("targetTemperature"),
+            "humidity": data.get("humidity"),
+            "heatingPower": data.get("heatingPower"),
+            "batteryState": data.get("batteryState"),
         }
 
     async def async_set_temperature(self, room_id: str, value: float) -> None:

--- a/custom_components/tado_x/number.py
+++ b/custom_components/tado_x/number.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
@@ -21,24 +23,40 @@ async def async_setup_entry(
     """Set up the Tado X offset number entity."""
     data = hass.data[DOMAIN][entry.entry_id]
     api = data["api"]
-    serial = data["serial"]
-    async_add_entities([TadoXOffsetNumber(api, serial)])
+    rooms = data.get("rooms", {})
+    entities = [
+        TadoXOffsetNumber(api, info) for info in rooms.values()
+    ]
+    async_add_entities(entities)
 
 
 class TadoXOffsetNumber(NumberEntity):
     """Entity to control the temperature offset of a Tado X device."""
 
-    _attr_name = "Temperature Offset"
     _attr_native_min_value = -5.0
     _attr_native_max_value = 5.0
     _attr_native_step = 0.1
 
-    def __init__(self, api, serial: str) -> None:
+    def __init__(self, api, info: dict[str, Any]) -> None:
         """Initialize the offset number."""
         self.api = api
-        self._serial = serial
-        self._attr_unique_id = f"{serial}_temperature_offset"
+        self._serial = info.get("serial")
+        room_name = info.get("name")
+        self._attr_name = (
+            f"{room_name} Temperature Offset" if room_name else "Temperature Offset"
+        )
+        if self._serial:
+            self._attr_unique_id = f"{self._serial}_temperature_offset"
+        else:
+            self._attr_unique_id = None
         self._attr_native_value = None
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._serial)} if self._serial else None,
+            manufacturer="tado°",
+            name=info.get("name"),
+            model=info.get("model"),
+            sw_version=info.get("firmware"),
+        )
 
     async def async_set_value(self, value: float) -> None:
         """Update the offset value via the API."""


### PR DESCRIPTION
## Summary
- store room device metadata (serial, model, firmware, name) during setup
- expose device info and extra attributes for climate entities
- expose device info for temperature offset numbers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9a8672aac83309bef3c8eb264023e