### PR TITLE
Handle serial field fallback for device identifiers

### DIFF
--- a/custom_components/tado_x/__init__.py
+++ b/custom_components/tado_x/__init__.py
@@ -19,7 +19,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     rooms_data = await api.async_get_rooms_devices(home_id)
     rooms: dict[str, dict[str, str | float | None]] = {}
     for room in rooms_data or []:
-        room_id = str(room.get("id") or room.get("serialNo"))
+        room_id = str(
+            room.get("id") or room.get("serialNo") or room.get("serial")
+        )
         if not room_id:
             continue
         room_name = room.get("name")
@@ -37,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         heating_power = room.get("heatingPower")
 
         device = (room.get("devices") or [None])[0] or {}
-        serial = device.get("serialNo")
+        serial = device.get("serialNo") or device.get("serial")
         model = device.get("model") or device.get("type")
         firmware = device.get("firmware") or device.get("firmwareVersion")
         battery_state = device.get("batteryState") or room.get("batteryState")

--- a/custom_components/tado_x/climate.py
+++ b/custom_components/tado_x/climate.py
@@ -54,7 +54,7 @@ class TadoXClimate(ClimateEntity):
         self._humidity = info.get("humidity")
         self._heating_power = info.get("heatingPower")
         self._battery_state = info.get("batteryState")
-        serial = info.get("serial")
+        serial = info.get("serial") or info.get("serialNo")
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)} if serial else None,
             manufacturer="tado°",

--- a/custom_components/tado_x/number.py
+++ b/custom_components/tado_x/number.py
@@ -40,7 +40,7 @@ class TadoXOffsetNumber(NumberEntity):
     def __init__(self, api, info: dict[str, Any]) -> None:
         """Initialize the offset number."""
         self.api = api
-        self._serial = info.get("serial")
+        self._serial = info.get("serial") or info.get("serialNo")
         room_name = info.get("name")
         self._attr_name = (
             f"{room_name} Temperature Offset" if room_name else "Temperature Offset"

--- a/custom_components/tado_x/sensor.py
+++ b/custom_components/tado_x/sensor.py
@@ -48,7 +48,7 @@ class TadoXBaseSensor(SensorEntity):
     def __init__(self, api, room_id: str, info: dict[str, Any]) -> None:
         self.api = api
         self._room_id = room_id
-        self._serial = info.get("serial")
+        self._serial = info.get("serial") or info.get("serialNo")
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._serial)} if self._serial else None,
             manufacturer="tado°",


### PR DESCRIPTION
## Summary
- add `serial` field fallback to `serialNo` for room and device identifiers
- apply consistent serial fallback across climate, sensor, and number entities

## Testing
- `python -m py_compile custom_components/tado_x/__init__.py custom_components/tado_x/climate.py custom_components/tado_x/number.py custom_components/tado_x/sensor.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9d66d5b8483308e79d56379ef2709