### PR TITLE
Handle dict response for rooms in Tado X integration

### DIFF
--- a/custom_components/tado_x/__init__.py
+++ b/custom_components/tado_x/__init__.py
@@ -25,8 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     home_id = int(entry.data[CONF_HOME_ID])
 
     rooms_data = await api.async_get_rooms_devices(home_id)
+    rooms_list = rooms_data.get("rooms") if isinstance(rooms_data, dict) else rooms_data
     rooms: dict[str, dict[str, str | float | None]] = {}
-    for room in rooms_data or []:
+    for room in rooms_list or []:
         room_id = str(
             room.get("id") or room.get("serialNo") or room.get("serial")
         )


### PR DESCRIPTION
## Summary
- Handle rooms API returning a dict by extracting the `rooms` list
- Iterate over normalized `rooms_list`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9d9f927a483309dc941bbac6da7e5